### PR TITLE
adding a local mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,20 @@
 
 Expects to run as part of the LSIO CI process. Not for public consumption.
 
-    docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -v ${TEMPDIR}:/ansible/readme linuxserver/doc-builder:latest
+**Running against remote: **
+
+    docker run --rm \
+     -e CONTAINER_NAME=${CONTAINER_NAME} \
+     -v ${TEMPDIR}:/ansible/readme \
+     linuxserver/doc-builder:latest
+     
+**Running locally: **
+
+If you need to test functionality just navigate to the folder with the readme-vars.yml and run: 
+
+    docker run --rm \
+     -v $(pwd):/tmp \
+     -e LOCAL=true \
+     linuxserver/doc-builder:latest
+     
+The output will be in a GENERATED.md in your current working directory.

--- a/roles/generate-docs/tasks/main.yml
+++ b/roles/generate-docs/tasks/main.yml
@@ -1,9 +1,11 @@
 ---
 - name: friendly debug
+  when: lookup('env', 'LOCAL') != "true"
   debug:
     msg: "{{ container_name }}"
 
-- name:
+- name: download variables
+  when: lookup('env', 'LOCAL') != "true"
   get_url:
     url: "https://raw.githubusercontent.com/{{ github_user }}/docker-{{ container_name }}/{{ github_branch }}/readme-vars.yml"
     dest: /tmp/readme-vars.yml
@@ -13,12 +15,22 @@
     file: "/tmp/readme-vars.yml"
 
 - name: create destination dir for generated readme
+  when: lookup('env', 'LOCAL') != "true"
   file:
     path: "readme/{{ project_name }}"
     state: directory
 
 - name: write readme file
+  when: lookup('env', 'LOCAL') != "true"
   template:
     src: ../templates/README.md.j2
     dest: "readme/{{ project_name }}/README.md"
   delegate_to: localhost
+
+- name: write readme file local
+  when: lookup('env', 'LOCAL') == "true"
+  template:
+    src: ../templates/README.md.j2
+    dest: "/tmp/GENERATED.md"
+  delegate_to: localhost
+


### PR DESCRIPTION
Useful when prepping a repo, you can also generate a local readmet to go with the commit and avoid the double build job/double commit. 