### PR TITLE
leftover port loop in optional block

### DIFF
--- a/roles/generate-docs/templates/README.md.j2
+++ b/roles/generate-docs/templates/README.md.j2
@@ -86,10 +86,6 @@ docker create \
 {% for item in optional_block_1_items %}
 {{ item }}
 {% endfor %}
-
-{% for item in param_ports %}
--p {{ item.external_port }}:{{ item.internal_port }} \
-{% endfor %}
 {% endif %}
 
 ### docker-compose


### PR DESCRIPTION
Looks like a typo, need this for the sonarr readme https://github.com/linuxserver/docker-sonarr/blob/pipeline/README.md thows a port binding in the main docker section. 