### PR TITLE
Optional params as block and custom compose

### DIFF
--- a/roles/generate-docs/templates/README.md.j2
+++ b/roles/generate-docs/templates/README.md.j2
@@ -93,7 +93,7 @@ docker create \
 Compatible with docker-compose v2 schemas.
 
 ```
----
+{% if not custom_compose %}---
 version: "2"
 services:
   {{ project_name }}:
@@ -126,7 +126,7 @@ services:
 {% endfor %}
 {% endif %}
     mem_limit: 4096m
-    restart: unless-stopped
+    restart: unless-stopped{% else %}{{ custom_compose }}{% endif %}
 ```
 
 ## Parameters
@@ -159,6 +159,14 @@ Container images are configured using parameters passed at runtime (such as thos
 {% endfor %}
 {% endif %}
 
+{% if optional_parameters %}
+## Optional Parameters
+
+{{ optional_parameters }}
+
+&nbsp;
+{% endif %}
+
 {% if common_param_env_vars_enabled %}
 ## User / Group Identifiers
 
@@ -175,6 +183,7 @@ In this instance `PUID=1001` and `PGID=1001`, to find yours use `id user` as bel
 {% endif %}
 
 &nbsp;
+
 {% if app_setup_block_enabled %}
 ## Application Setup
 


### PR DESCRIPTION
A little lazy on the optional parameters as I would like to also include custom header and styles to the ones that need this. 

The compose is needed for when we give a full example in a multi service project with multiple DB backends etc. 