### PR TITLE
Full custom readme option

### DIFF
--- a/roles/generate-docs/tasks/main.yml
+++ b/roles/generate-docs/tasks/main.yml
@@ -20,17 +20,38 @@
     path: "readme/{{ project_name }}"
     state: directory
 
-- name: write readme file
-  when: lookup('env', 'LOCAL') != "true"
+- name: write readme file full template
+  when: 
+    - lookup('env', 'LOCAL') != "true"
+    - full_custom_readme is not defined
   template:
     src: ../templates/README.md.j2
     dest: "readme/{{ project_name }}/README.md"
   delegate_to: localhost
 
-- name: write readme file local
-  when: lookup('env', 'LOCAL') == "true"
+- name: write readme file local full template
+  when: 
+    - lookup('env', 'LOCAL') == "true"
+    - full_custom_readme is not defined
   template:
     src: ../templates/README.md.j2
     dest: "/tmp/GENERATED.md"
   delegate_to: localhost
 
+- name: write readme file custom
+  when: 
+    - lookup('env', 'LOCAL') != "true"
+    - full_custom_readme is defined
+  template:
+    src: ../templates/CUSTOM.md.j2
+    dest: "readme/{{ project_name }}/README.md"
+  delegate_to: localhost
+
+- name: write readme file local custom
+  when: 
+    - lookup('env', 'LOCAL') == "true"
+    - full_custom_readme is defined
+  template:
+    src: ../templates/CUSTOM.md.j2
+    dest: "/tmp/GENERATED.md"
+  delegate_to: localhost

--- a/roles/generate-docs/templates/CUSTOM.md.j2
+++ b/roles/generate-docs/templates/CUSTOM.md.j2
@@ -1,0 +1,1 @@
+{{ full_custom_readme }}


### PR DESCRIPTION
Face value this looks stupid , but it is needed for the CI process on some of our more custom repos that do not fit in line with our default readme. 

This is specifically needed for the Jenkins build file templating system so we can full loop the build logic on this repo before pushing the changes to the rest of the repos. 