### PR TITLE
adding a chmod command to template genration

### DIFF
--- a/roles/generate-docs/tasks/main.yml
+++ b/roles/generate-docs/tasks/main.yml
@@ -55,3 +55,9 @@
     src: ../templates/CUSTOM.md.j2
     dest: "/tmp/GENERATED.md"
   delegate_to: localhost
+
+- name: Allow non root host to delete temp files
+  when:
+    - lookup('env', 'LOCAL') != "true"
+  command: chmod -R 777 /ansible/readme
+  delegate_to: localhost


### PR DESCRIPTION
We need this for X86 nodes that are not running as root as the output from the docker container will have root permissions. 