### PR TITLE
Pull header PSA out of readmes

### DIFF
--- a/roles/generate-docs/templates/DOCUMENTATION.md.j2
+++ b/roles/generate-docs/templates/DOCUMENTATION.md.j2
@@ -17,7 +17,7 @@
 
 ## Supported Architectures
 
-Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list). 
+Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and our announcement [here](https://blog.linuxserver.io/2019/02/21/the-lsio-pipeline-project/). 
 
 Simply pulling `{{ lsio_project_name_short }}/{{ project_name }}` should retrieve the correct image for your arch, but you can also pull specific arch images via tags.
 

--- a/roles/generate-docs/templates/README.md.j2
+++ b/roles/generate-docs/templates/README.md.j2
@@ -14,12 +14,6 @@ Find us at:
 * [Blog]({{ lsio_blog_url }}) - {{ lsio_blog_desc }}
 * [Podcast]({{ lsio_podcast_url }}) - {{ lsio_podcast_desc }}
 
-# PSA: Changes are happening
-
-From August 2018 onwards, Linuxserver are in the midst of switching to a new CI platform which will enable us to build and release multiple architectures under a single repo. To this end, existing images for `arm64` and `armhf` builds are being deprecated. They are replaced by a manifest file in each container which automatically pulls the correct image for your architecture. You'll also be able to pull based on a specific architecture tag.
-
-TLDR: Multi-arch support is changing from multiple repos to one repo per container image.
-
 # [{{ lsio_project_name_short }}/{{ project_name }}]({{ project_lsio_github_repo_url }})
 [![]({{ lsio_shieldsio_discord }})]({{ lsio_discord_url }})
 [![]({{ lsio_microbadger_badge_version_url }}/{{ project_name }}.svg)]({{ lsio_microbadger_image_url }}/{{ project_name }} "{{ lsio_microbadger_link_desc }}")

--- a/roles/generate-docs/templates/README.md.j2
+++ b/roles/generate-docs/templates/README.md.j2
@@ -34,7 +34,7 @@ Find us at:
 
 ## Supported Architectures
 
-Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list). 
+Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and our announcement [here](https://blog.linuxserver.io/2019/02/21/the-lsio-pipeline-project/). 
 
 Simply pulling `{{ lsio_project_name_short }}/{{ project_name }}` should retrieve the correct image for your arch, but you can also pull specific arch images via tags.
 


### PR DESCRIPTION
The pipeline migration is now complete we should rip this header out. 
https://blog.linuxserver.io/2019/02/21/the-lsio-pipeline-project/
