### PR TITLE
Fancy badges

### DIFF
--- a/roles/generate-docs/templates/DOCUMENTATION.md.j2
+++ b/roles/generate-docs/templates/DOCUMENTATION.md.j2
@@ -1,12 +1,12 @@
 # [{{ lsio_project_name_short }}/{{ project_name }}]({{ project_lsio_github_repo_url }})
 
-[![]({{ lsio_shieldsio_discord }})]({{ lsio_discord_url }})
-[![]({{ lsio_microbadger_badge_version_url }}/{{ project_name }}.svg)]({{ lsio_microbadger_image_url }}/{{ project_name }} "{{ lsio_microbadger_link_desc }}")
-[![]({{ lsio_microbadger_badge_image_url }}/{{ project_name }}.svg)]({{ lsio_microbadger_image_url }}/{{ project_name }} "{{ lsio_microbadger_link_desc }}")
-![Docker Pulls]({{ lsio_shieldsio_pull_count_url }}/{{ project_name }}.svg)
-![Docker Stars]({{ lsio_shieldsio_stars_count_url }}/{{ project_name }}.svg)
-[![Build Status]({{ lsio_ci_url }}/buildStatus/icon?job=Docker-Pipeline-Builders/docker-{{ project_name }}/master)]({{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/master/)
-[![]({{ lsio_object_url }}/linuxserver/{{ project_name }}/latest/badge.svg)]({{ lsio_object_url }}/linuxserver/{{ project_name }}/latest/index.html)
+[![GitHub Release]({{ lsio_shieldsio_github_release }})]({{ project_lsio_github_repo_url }}/releases)
+[![MicroBadger Layers]({{ lsio_shieldsio_microbadger_layers }})]({{ lsio_microbadger_url }}/{{ project_name }} "{{ lsio_microbadger_desc }}")
+[![MicroBadger Size]({{ lsio_shieldsio_microbadger_size }})]({{ lsio_microbadger_url }}/{{ project_name }} "{{ lsio_microbadger_desc }}")
+[![Docker Pulls]({{ lsio_shieldsio_docker_pulls }})]({{ project_lsio_docker_hub_url }}/{{ project_name }})
+[![Docker Stars]({{ lsio_shieldsio_docker_stars }})]({{ project_lsio_docker_hub_url }}/{{ project_name }})
+[![Build Status]({{ lsio_ci_badge }})]({{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/master/)
+[![]({{ lsio_object_url }}/{{ lsio_project_name_short }}/{{ project_name }}/latest/badge.svg)]({{ lsio_object_url }}/{{ lsio_project_name_short }}/{{ project_name }}/latest/index.html)
 
 {{ project_blurb }}
 {% if project_blurb_optional_extras_enabled %}
@@ -17,7 +17,7 @@
 
 ## Supported Architectures
 
-Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and our announcement [here](https://blog.linuxserver.io/2019/02/21/the-lsio-pipeline-project/). 
+Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and our announcement [here]({{ lsio_blog_url }}/2019/02/21/the-lsio-pipeline-project/).
 
 Simply pulling `{{ lsio_project_name_short }}/{{ project_name }}` should retrieve the correct image for your arch, but you can also pull specific arch images via tags.
 
@@ -344,11 +344,11 @@ This snippet has been tested with {{ lsio_project_name|capitalize}}'s [Let's Enc
 
 ## Support Info
 
-* Shell access whilst the container is running: 
+* Shell access whilst the container is running:
   * `docker exec -it {{ project_name }} /bin/bash`
-* To monitor the logs of the container in realtime: 
+* To monitor the logs of the container in realtime:
   * `docker logs -f {{ project_name }}`
-* Container version number 
+* Container version number
   * `docker inspect -f {% raw %}'{{ index .Config.Labels "build_version" }}'{% endraw %} {{ project_name }}`
 * Image version number
   * `docker inspect -f {% raw %}'{{ index .Config.Labels "build_version" }}'{% endraw %} {{ lsio_project_name_short }}/{{ project_name }}`

--- a/roles/generate-docs/templates/README.md.j2
+++ b/roles/generate-docs/templates/README.md.j2
@@ -1,5 +1,12 @@
 [![{{ lsio_project_name }}]({{ lsio_primary_logo_url }})]({{ lsio_full_url }})
 
+[![Blog]({{ lsio_shieldsio_static_blog }})]({{ lsio_blog_url }} "{{ lsio_blog_desc }}")
+[![Discord]({{ lsio_shieldsio_discord }})]({{ lsio_discord_url }} "{{ lsio_discord_desc }}")
+[![Discourse]({{ lsio_shieldsio_discourse_topics }})]({{ lsio_discourse_url }} "{{ lsio_discourse_desc }}")
+[![Fleet]({{ lsio_shieldsio_static_fleet }})]({{ lsio_fleet_url }} "{{ lsio_fleet_desc }}")
+[![Podcast]({{ lsio_shieldsio_static_podcast }})]({{ lsio_podcast_url }} "{{ lsio_podcast_desc }}")
+[![Open Collective]({{ lsio_shieldsio_opencollective_all }})]({{ lsio_opencollective_url }} "{{ lsio_opencollective_desc }}")
+
 The [LinuxServer.io]({{ lsio_full_url }}) team brings you another container release featuring :-
 
  * regular and timely application updates
@@ -9,18 +16,21 @@ The [LinuxServer.io]({{ lsio_full_url }}) team brings you another container rele
  * regular security updates
 
 Find us at:
-* [Discord]({{ lsio_discord_url }}) - {{ lsio_discord_desc }}
-* [IRC]({{ lsio_irc_url }}) - {{ lsio_irc_desc }}
 * [Blog]({{ lsio_blog_url }}) - {{ lsio_blog_desc }}
+* [Discord]({{ lsio_discord_url }}) - {{ lsio_discord_desc }}
+* [Discourse]({{ lsio_discourse_url }}) - {{ lsio_discourse_desc }}
+* [Fleet]({{ lsio_fleet_url }}) - {{ lsio_fleet_desc }}
+* [Podcast]({{ lsio_podcast_url }}) - {{ lsio_podcast_desc }}
+* [Open Collective]({{ lsio_opencollective_url }}) - {{ lsio_opencollective_desc }}
 
 # [{{ lsio_project_name_short }}/{{ project_name }}]({{ project_lsio_github_repo_url }})
-[![]({{ lsio_shieldsio_discord }})]({{ lsio_discord_url }})
-[![]({{ lsio_microbadger_badge_version_url }}/{{ project_name }}.svg)]({{ lsio_microbadger_image_url }}/{{ project_name }} "{{ lsio_microbadger_link_desc }}")
-[![]({{ lsio_microbadger_badge_image_url }}/{{ project_name }}.svg)]({{ lsio_microbadger_image_url }}/{{ project_name }} "{{ lsio_microbadger_link_desc }}")
-![Docker Pulls]({{ lsio_shieldsio_pull_count_url }}/{{ project_name }}.svg)
-![Docker Stars]({{ lsio_shieldsio_stars_count_url }}/{{ project_name }}.svg)
-[![Build Status]({{ lsio_ci_url }}/buildStatus/icon?job=Docker-Pipeline-Builders/docker-{{ project_name }}/master)]({{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/master/)
-[![]({{ lsio_object_url }}/linuxserver/{{ project_name }}/latest/badge.svg)]({{ lsio_object_url }}/linuxserver/{{ project_name }}/latest/index.html)
+[![GitHub Release]({{ lsio_shieldsio_github_release }})]({{ project_lsio_github_repo_url }}/releases)
+[![MicroBadger Layers]({{ lsio_shieldsio_microbadger_layers }})]({{ lsio_microbadger_url }}/{{ project_name }} "{{ lsio_microbadger_desc }}")
+[![MicroBadger Size]({{ lsio_shieldsio_microbadger_size }})]({{ lsio_microbadger_url }}/{{ project_name }} "{{ lsio_microbadger_desc }}")
+[![Docker Pulls]({{ lsio_shieldsio_docker_pulls }})]({{ project_lsio_docker_hub_url }}/{{ project_name }})
+[![Docker Stars]({{ lsio_shieldsio_docker_stars }})]({{ project_lsio_docker_hub_url }}/{{ project_name }})
+[![Build Status]({{ lsio_ci_badge }})]({{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/master/)
+[![]({{ lsio_object_url }}/{{ lsio_project_name_short }}/{{ project_name }}/latest/badge.svg)]({{ lsio_object_url }}/{{ lsio_project_name_short }}/{{ project_name }}/latest/index.html)
 
 {{ project_blurb }}
 {% if project_blurb_optional_extras_enabled %}
@@ -33,7 +43,7 @@ Find us at:
 
 ## Supported Architectures
 
-Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and our announcement [here](https://blog.linuxserver.io/2019/02/21/the-lsio-pipeline-project/). 
+Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and our announcement [here]({{ lsio_blog_url }}/2019/02/21/the-lsio-pipeline-project/).
 
 Simply pulling `{{ lsio_project_name_short }}/{{ project_name }}` should retrieve the correct image for your arch, but you can also pull specific arch images via tags.
 
@@ -342,17 +352,17 @@ This snippet has been tested with {{ lsio_project_name|capitalize}}'s [Let's Enc
 
 * Shell access whilst the container is running: `docker exec -it {{ project_name }} /bin/bash`
 * To monitor the logs of the container in realtime: `docker logs -f {{ project_name }}`
-* container version number 
+* container version number
   * `docker inspect -f {% raw %}'{{ index .Config.Labels "build_version" }}'{% endraw %} {{ project_name }}`
 * image version number
   * `docker inspect -f {% raw %}'{{ index .Config.Labels "build_version" }}'{% endraw %} {{ lsio_project_name_short }}/{{ project_name }}`
 
 ## Updating Info
 
-Most of our images are static, versioned, and require an image update and container recreation to update the app inside. With some exceptions (ie. nextcloud, plex), we do not recommend or support updating apps inside the container. Please consult the [Application Setup](#application-setup) section above to see if it is recommended for the image.  
-  
-Below are the instructions for updating containers:  
-  
+Most of our images are static, versioned, and require an image update and container recreation to update the app inside. With some exceptions (ie. nextcloud, plex), we do not recommend or support updating apps inside the container. Please consult the [Application Setup](#application-setup) section above to see if it is recommended for the image.
+
+Below are the instructions for updating containers:
+
 ### Via Docker Run/Create
 * Update the image: `docker pull {{ lsio_project_name_short }}/{{ project_name }}`
 * Stop the running container: `docker stop {{ project_name }}`
@@ -383,9 +393,9 @@ Below are the instructions for updating containers:
 
 ## Building locally
 
-If you want to make local modifications to these images for development purposes or just to customize the logic: 
+If you want to make local modifications to these images for development purposes or just to customize the logic:
 ```
-git clone https://github.com/linuxserver/docker-{{ project_name }}.git
+git clone https://github.com/{{ lsio_project_name_short }}/docker-{{ project_name }}.git
 cd docker-{{ project_name }}
 docker build \
   --no-cache \

--- a/vars/_container-vars-blank
+++ b/vars/_container-vars-blank
@@ -5,7 +5,8 @@ project_name: name
 project_url: "https://url.com/"
 project_logo: "http://www.logo.com/logo.png"
 project_blurb: "[{{ project_name|capitalize }}]({{ project_url }}) short description goes here."
-project_lsio_github_repo_url: "https://github.com/linuxserver/docker-{{ project_name }}"
+project_lsio_github_repo_url: "https://github.com/{{ lsio_project_name_short }}/docker-{{ project_name }}"
+project_lsio_docker_hub_url: "https://hub.docker.com/r/{{ lsio_project_name_short }}/{{ project_name }}"
 
 project_blurb_optional_extras_enabled: false
 project_blurb_optional_extras: []

--- a/vars/common
+++ b/vars/common
@@ -9,11 +9,18 @@ lsio_project_name_short: "linuxserver"
 lsio_short_url: "{{ lsio_project_name }}"
 lsio_full_url: "https://{{ lsio_project_name }}"
 lsio_blog_url: "https://blog.{{ lsio_short_url }}"
-lsio_discord_url: "https://discord.gg/YWrKVTn"
-lsio_irc_url: "https://irc.{{ lsio_short_url }}"
-lsio_podcast_url: "https://anchor.fm/linuxserverio"
 lsio_ci_url: "https://ci.linuxserver.io"
+lsio_discord_url: "https://discord.gg/YWrKVTn"
+lsio_discourse_url: "https://discourse.{{ lsio_short_url }}"
+lsio_fleet_url: "https://fleet.{{ lsio_short_url }}"
+lsio_irc_url: "https://irc.{{ lsio_short_url }}"
+lsio_microbadger_url: "https://microbadger.com/images/{{ lsio_project_name_short }}"
 lsio_object_url: "https://lsio-ci.ams3.digitaloceanspaces.com"
+lsio_opencollective_url: "https://opencollective.com/{{ lsio_project_name_short }}"
+lsio_podcast_url: "https://anchor.fm/linuxserverio"
+
+# This goes in readme-vars in each individual repo
+project_lsio_docker_hub_url: "https://hub.docker.com/r/{{ lsio_project_name_short }}/{{ project_name }}"
 
 # supported architectures
 arch_x86_64: "x86-64"
@@ -21,9 +28,13 @@ arch_arm64: "arm64"
 arch_armhf: "armhf"
 
 # descriptions
-lsio_discord_desc: "realtime support / chat with the community and the team."
 lsio_blog_desc: "all the things you can do with our containers including How-To guides, opinions and much more!"
+lsio_discord_desc: "realtime support / chat with the community and the team."
+lsio_discourse_desc: "post on our community forum."
+lsio_fleet_desc: "an online web interface which displays all of our maintained images."
 lsio_irc_desc: "on freenode at `#{{ lsio_project_name }}`. Our primary support channel is Discord."
+lsio_microbadger_desc: "Get your own version badge on microbadger.com"
+lsio_opencollective_desc: "please consider helping us by either donating or contributing to our budget"
 lsio_podcast_desc: "on hiatus. Coming back soon (late 2018)."
 
 # asset urls
@@ -31,13 +42,19 @@ lsio_primary_logo_url: https://raw.githubusercontent.com/linuxserver/docker-temp
 lsio_favicon_logo_url: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver-ls-logo.png
 
 # badges
-lsio_microbadger_badge_version_url: https://images.microbadger.com/badges/version/linuxserver
-lsio_microbadger_badge_image_url: https://images.microbadger.com/badges/image/linuxserver
-lsio_microbadger_image_url: https://microbadger.com/images/linuxserver
-lsio_microbadger_link_desc: "Get your own version badge on microbadger.com"
-lsio_shieldsio_pull_count_url: https://img.shields.io/docker/pulls/linuxserver
-lsio_shieldsio_stars_count_url: https://img.shields.io/docker/stars/linuxserver
-lsio_shieldsio_discord: https://img.shields.io/discord/354974912613449730.svg?logo=discord&label=LSIO%20Discord&style=flat-square
+lsio_ci_badge: "{{ lsio_ci_url }}/view/all/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/master/badge/icon?style=flat-square"
+lsio_shieldsio_discord: "https://img.shields.io/discord/354974912613449730.svg?style=flat-square&color=E68523&label=Discord&logo=discord&logoColor=FFFFFF"
+lsio_shieldsio_discourse_topics: "https://img.shields.io/discourse/https/discourse.{{ lsio_short_url }}/topics.svg?style=flat-square&color=E68523&logo=discourse&logoColor=FFFFFF"
+lsio_shieldsio_docker_pulls: "https://img.shields.io/docker/pulls/{{ lsio_project_name_short }}/{{ project_name }}.svg?style=flat-square&color=E68523"
+lsio_shieldsio_docker_stars: "https://img.shields.io/docker/stars/{{ lsio_project_name_short }}/{{ project_name }}.svg?style=flat-square&color=E68523"
+lsio_shieldsio_github_release: "https://img.shields.io/github/release/{{ lsio_project_name_short }}/docker-{{ project_name }}.svg?style=flat-square&color=E68523"
+lsio_shieldsio_microbadger_layers: "https://img.shields.io/microbadger/layers/{{ lsio_project_name_short }}/{{ project_name }}.svg?style=flat-square&color=E68523"
+lsio_shieldsio_microbadger_size: "https://img.shields.io/microbadger/image-size/{{ lsio_project_name_short }}/{{ project_name }}.svg?style=flat-square&color=E68523"
+lsio_shieldsio_opencollective_all: "https://img.shields.io/opencollective/all/{{ lsio_project_name_short }}.svg?style=flat-square&color=E68523&label=Open%20Collective%20Supporters"
+lsio_shieldsio_static_blog: "https://img.shields.io/static/v1.svg?style=flat-square&color=E68523&label={{ lsio_project_name }}&message=Blog"
+lsio_shieldsio_static_fleet: "https://img.shields.io/static/v1.svg?style=flat-square&color=E68523&label={{ lsio_project_name }}&message=Fleet"
+lsio_shieldsio_static_irc: "https://img.shields.io/static/v1.svg?style=flat-square&color=E68523&label={{ lsio_project_name }}&message=IRC"
+lsio_shieldsio_static_podcast: "https://img.shields.io/static/v1.svg?style=flat-square&color=E68523&label={{ lsio_project_name }}&message=Podcast"
 
 ######
 # Common Params
@@ -50,4 +67,3 @@ common_container_param_config_description: ""
 common_param_env_vars:
   - { env_var: "PUID", env_value: "1000", desc: "for UserID - see below for explanation" }
   - { env_var: "PGID", env_value: "1000", desc: "for GroupID - see below for explanation" }
-


### PR DESCRIPTION
A lot going on here so I'll try to bullet point:

- Style all badges (flat square)
- Color most badges (orange)
- - Do not color badges where the color indicates a status (CI badges)
- Move any non-project specific badges/links under the LSIO logo (lsio general badges vs project specific badges). Only Discord was moved (the rest are new).
- - Create new badges for Blog, Discourse, Fleet, Podcast, and Open Collective in the lsio general badges area.
- - All lsio general badges have image, link, and description variables (project specific badges do not)
- Update the `Find us at:` section with Discourse, Fleet, Podcast, and Open Collective
- Replace MicroBadger version with GitHub release (MB prepended the architecture and truncated the version after too many characters)
- Split the MicroBadger Size and Layers into two badges
- Use the same set of project badges in Documentation and Readme. Documentation does not have lsio general badges.
- Add link alt text to all badges (this may be causing the broken image link for the Digital Ocean CI on GitHub, I'll test and update this if it makes a difference) **Edit:** Confirmed this is the issue, but only the Digital Ocean CI has problems displaying so I've only left that one empty.

Demo:

https://gist.github.com/nemchik/97df866c91779fe533b577e6c1d10878