### PR TITLE
Fix Docker hub links

### DIFF
--- a/roles/generate-docs/templates/DOCUMENTATION.md.j2
+++ b/roles/generate-docs/templates/DOCUMENTATION.md.j2
@@ -3,8 +3,8 @@
 [![GitHub Release]({{ lsio_shieldsio_github_release }})]({{ project_lsio_github_repo_url }}/releases)
 [![MicroBadger Layers]({{ lsio_shieldsio_microbadger_layers }})]({{ lsio_microbadger_url }}/{{ project_name }} "{{ lsio_microbadger_desc }}")
 [![MicroBadger Size]({{ lsio_shieldsio_microbadger_size }})]({{ lsio_microbadger_url }}/{{ project_name }} "{{ lsio_microbadger_desc }}")
-[![Docker Pulls]({{ lsio_shieldsio_docker_pulls }})]({{ project_lsio_docker_hub_url }}/{{ project_name }})
-[![Docker Stars]({{ lsio_shieldsio_docker_stars }})]({{ project_lsio_docker_hub_url }}/{{ project_name }})
+[![Docker Pulls]({{ lsio_shieldsio_docker_pulls }})]({{ project_lsio_docker_hub_url }})
+[![Docker Stars]({{ lsio_shieldsio_docker_stars }})]({{ project_lsio_docker_hub_url }})
 [![Build Status]({{ lsio_ci_badge }})]({{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/master/)
 [![]({{ lsio_object_url }}/{{ lsio_project_name_short }}/{{ project_name }}/latest/badge.svg)]({{ lsio_object_url }}/{{ lsio_project_name_short }}/{{ project_name }}/latest/index.html)
 

--- a/roles/generate-docs/templates/README.md.j2
+++ b/roles/generate-docs/templates/README.md.j2
@@ -27,8 +27,8 @@ Find us at:
 [![GitHub Release]({{ lsio_shieldsio_github_release }})]({{ project_lsio_github_repo_url }}/releases)
 [![MicroBadger Layers]({{ lsio_shieldsio_microbadger_layers }})]({{ lsio_microbadger_url }}/{{ project_name }} "{{ lsio_microbadger_desc }}")
 [![MicroBadger Size]({{ lsio_shieldsio_microbadger_size }})]({{ lsio_microbadger_url }}/{{ project_name }} "{{ lsio_microbadger_desc }}")
-[![Docker Pulls]({{ lsio_shieldsio_docker_pulls }})]({{ project_lsio_docker_hub_url }}/{{ project_name }})
-[![Docker Stars]({{ lsio_shieldsio_docker_stars }})]({{ project_lsio_docker_hub_url }}/{{ project_name }})
+[![Docker Pulls]({{ lsio_shieldsio_docker_pulls }})]({{ project_lsio_docker_hub_url }})
+[![Docker Stars]({{ lsio_shieldsio_docker_stars }})]({{ project_lsio_docker_hub_url }})
 [![Build Status]({{ lsio_ci_badge }})]({{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/master/)
 [![]({{ lsio_object_url }}/{{ lsio_project_name_short }}/{{ project_name }}/latest/badge.svg)]({{ lsio_object_url }}/{{ lsio_project_name_short }}/{{ project_name }}/latest/index.html)
 


### PR DESCRIPTION
I made a small mistake with this

Accidentally setup https://hub.docker.com/r/linuxserver/sabnzbd/sabnzbd instead of https://hub.docker.com/r/linuxserver/sabnzbd

I'll follow up in a minute with a fix for the other file.